### PR TITLE
Add PKG_CXXFLAGS to Makevars

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -25,6 +25,7 @@ PKG_LIBS = `$(R_HOME)/bin/Rscript -e "Rcpp:::LdFlags()"`
 ## comfortable with autoconf and its related tools.
 
 CXX_STD = CXX11
+PKG_CXXFLAGS = -std=c++11
 
 PKG_CPPFLAGS = -I. -Icyclops -DR_BUILD -DDOUBLE_PRECISION
 


### PR DESCRIPTION
Setting the PKG_CXXFLAGS flag to -std=c++11 allows Rcpp to correctly use the c++11 standard in Linux Mint. I'm not really sure why the c++11 flag that's there already isn't recognized, but this fixes the problem. I see absolutely no reason why this change should cause any problem on any other system, but maybe someone should at least build with it on a Mac before this gets merged in.
