### PR TITLE
Avoid using tr1 even on Windows.

### DIFF
--- a/src/cyclops/Types.h
+++ b/src/cyclops/Types.h
@@ -30,17 +30,10 @@
 //    }
 // #endif
 
-#ifdef WIN_BUILD
-    #include <tr1/unordered_map>
-    namespace bsccs {
-        using std::tr1::unordered_map;
-    }
-#else
-    #include <unordered_map>
-    namespace bsccs {
-        using std::unordered_map;
-    }
-#endif
+#include <unordered_map>
+namespace bsccs {
+    using std::unordered_map;
+}
 
 namespace bsccs {
 


### PR DESCRIPTION
Rtools for Windows already have modern compilers (Rtools42 has gcc10, Rtools43 gcc12) and tr1 is not available with LLVM/libc++, so using it prevents the package for building for Windows/aarch64.

With this change, the package builds and checks fine on my Windows/aarch64 using LLVM 17.