### PR TITLE
81 initialize intercept

### DIFF
--- a/R/ModelFit.R
+++ b/R/ModelFit.R
@@ -253,6 +253,7 @@ fitCyclopsModel <- function(cyclopsData,
             betas <- c(1.0, betas)
         }
         .cyclopsSetBeta(cyclopsData$cyclopsInterfacePtr, betas)
+        .cyclopsSetStartingBeta(cyclopsData$cyclopsInterfacePtr, betas)
     }
 
     # Handle weights

--- a/R/ModelFit.R
+++ b/R/ModelFit.R
@@ -237,6 +237,24 @@ fitCyclopsModel <- function(cyclopsData,
         }
     }
 
+    if (.cyclopsGetHasIntercept(cyclopsData) &&
+        is.null(prior$fitHook) &&
+        is.null(startingCoefficients)) {
+        yMean <- mean(getYVector(cyclopsData))
+        if (cyclopsData$modelType == "lr") {
+            interceptValue <- log(yMean / (1 - yMean))
+        } else if (cyclopsData$modelType == "pr") {
+            interceptValue <- log(yMean)
+        } else if (cyclopsData$modelType == "ls") {
+            interceptValue <- yMean
+        }
+        betas <- c(interceptValue, rep(0.0, getNumberOfCovariates(cyclopsData) - 1))
+        if (.cyclopsGetHasOffset(cyclopsData)) {
+            betas <- c(1.0, betas)
+        }
+        .cyclopsSetBeta(cyclopsData$cyclopsInterfacePtr, betas)
+    }
+
     # Handle weights
 
     weightsUnsorted <- TRUE


### PR DESCRIPTION
Hi @msuchard ,

Here are my suggested changes as discussed in #81 

I've implemented the intercept initialization for unconditioned logistic regression, Poisson and least squares. 

This initialization is only added if there is an intercept, no starting coefficients have been given and the `prior$fitHook` is null. I also added support for offsets, which was required to pass tests. 

There is now a single test failing, 

```text
══ Failed tests ════════════════════════════════════════════════════════════════
── Failure ('test-sqlConstructor.R:67:5'): Test constructor and append ─────────
coef(cyclopsFit) not equivalent to coef(cyclopsFitF).
5/5 mismatches (average diff: 1.37e-06)
[1]  3.04e+00 -  3.04e+00 ==  2.26e-06
[2] -4.54e-01 - -4.54e-01 == -7.79e-08
[3] -2.93e-01 - -2.93e-01 == -7.79e-08
[4]  1.27e-05 -  1.49e-05 == -2.22e-06
[5]  1.27e-05 -  1.49e-05 == -2.22e-06
```

This is failing because the `appendSqlCyclopsData` doesn't set the intercept flag so the consequent fit doesn't initialize the intercept with the new method. Looking at the usage of `appendSqlCyclopsData` it looks to be a legacy method that's only used in tests. My suggestion would be to remove this test. Other option is to make this method aware of constant columns in the data and set the intercept flag.

I also did some reverse dependency checking, ran the tests in `IterativeHardThresholding` and `BrokenAdaptiveRidge` with these change and everything passed.

As a sidenote, the ubuntu 20.04 runner used in this repo is has been deprecated (15th of april). I could make a separate PR to upgrade it to 24.04.  Would probably be better if you give me access so I can work in a branch on this repo. 

Let me know what you think!
Egill